### PR TITLE
Implemented GET endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,8 @@
+from flask import Flask,request,redirect,jsonify
 import string
 import random
-from flask import Flask,request,jsonify
+import os
+
 
 app = Flask(__name__)
 
@@ -41,6 +43,14 @@ def shorten_url():
         return jsonify({'error':'Invalid long url provided'}),400
 
 
+@app.route('/<short_url>',methods=['GET'])
+def redirect_url(short_url):
+    long_url = url_mapping.get(short_url)
+    if not long_url:
+        return jsonify({"error:":"Short url not found"}),404
+    else:
+        return redirect(long_url)
+    
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(host='0.0.0.0',port=os.environ.get('PORT',5000))
 


### PR DESCRIPTION
## What?
I have implemented GET endpoint, `/short_url` that will redirect user to original url with 302 response code.
## Why?
We want users to click on short_url so they can redirect to long_url.
## How?
From url mapping dictionary short_url extracted and then redirect it to long_url.
## Testing?
Using postman, added screenshots.
## Screenshots (optional)
![image](https://user-images.githubusercontent.com/52626507/230456937-51522830-96cf-448a-b86c-5f64966ec904.png)
When short_url is not in dictionary then response code is 404.
![image](https://user-images.githubusercontent.com/52626507/230457528-559efd4d-c0da-438d-af61-1fff21c162e4.png)

## Anything Else?